### PR TITLE
Update to skip pseudo localization when the nopseudo option is true

### DIFF
--- a/JsonFile.js
+++ b/JsonFile.js
@@ -321,7 +321,7 @@ JsonFile.prototype.localizeText = function(translations, locale) {
             baseTranslation = key;
             
             var typeValue = this.datatype.replace("x-", "");
-            if (((this.project.settings[typeValue] === undefined) ||
+            if (!this.project.settings.nopseudo && ((this.project.settings[typeValue] === undefined) ||
                 (this.project.settings[typeValue] &&
                 !(this.project.settings[typeValue].disablePseudo === true))) &&
                 PseudoFactory.isPseudoLocale(locale, this.project)){

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ i.e. `appinfo.json`, `qcardinfo.json`
 This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.1.1
+* Update to skip pseudo localizaton data the `--nopseudo` option is true. 
+  If not, it occurs an error when the pseudo locale is not defined on project.
+
 v1.1.0
 * Updated dependencies. (loctool: 2.22.0)
 * Support the pseudo localization.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "JsonFileType.js",
     "description": "json type of file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
* Update to skip pseudo localizaton data the `--nopseudo` option is true.  If not, it occurs an error when the pseudo locale is not defined on project.
  * issue case example) When the pseudo locale is not defined on config fie, the pseudo locale list is from loctool's default one. and it says the en-AU is  a pseudo locale.